### PR TITLE
Extended path handling for local patching due to rate limiting issues on github

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -231,6 +231,7 @@ class Patches implements PluginInterface, EventSubscriberInterface {
               }
             }
           }
+          $extra['patches'] = $this->resolveRelativePathPatches($package, $extra['patches']);
           $this->patches = $this->arrayMergeRecursiveDistinct($this->patches, $extra['patches']);
         }
         // Unset installed patches for this package

--- a/src/Patches.php
+++ b/src/Patches.php
@@ -175,8 +175,8 @@ class Patches implements PluginInterface, EventSubscriberInterface {
     $resolvedPatches = array();
     $vendorDir = $this->composer->getConfig()->get('vendor-dir');
     $packagePath = str_replace(dirname($vendorDir) . '/', '', $this->composer->getInstallationManager()->getInstallPath($package));
-    foreach ($patches as $packageName => $patches) {
-      foreach ($patches as $description => $path) {
+    foreach ($patches as $packageName => $packagePatches) {
+      foreach ($packagePatches as $description => $path) {
         if (strpos($path, './') === 0) {
           $path = './' . $packagePath . '/' . substr($path, 2);
           // Check for jailbreaks.

--- a/tests/PackageInstallationTest.php
+++ b/tests/PackageInstallationTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace cweagans\Composer\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Composer\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+class PackageInstallationTest extends TestCase
+{
+
+  private $filesystem;
+
+  private $tempDir;
+
+  private $packeDir;
+
+  private $vendorDir;
+
+  private $composerLock;
+
+  protected function setUp(): void
+  {
+    parent::setUp();
+    $this->filesystem = new Filesystem();
+    $this->tempDir = sys_get_temp_dir() . '/composer-test-' . uniqid();
+    $this->packeDir = $this->tempDir . '/tests/_data/dep-test-package';
+    $this->vendorDir = $this->packeDir . '/vendor';
+    $this->composerLock = $this->packeDir . '/composer.lock';
+
+    // Create temp directory.
+    $this->filesystem->mkdir($this->tempDir);
+
+    // Copy this packages full code into the temp directory.
+    $this->filesystem->mirror(
+      __DIR__ . '/../',
+      $this->tempDir
+    );
+  }
+
+  protected function tearDown(): void
+  {
+    // Clean up the temporary directory
+    if ($this->filesystem->exists($this->tempDir) && !getenv(
+        'COMPOSER_TESTS_KEEP_TEMP_DIR'
+      )) {
+      $this->filesystem->remove($this->tempDir);
+    }
+    parent::tearDown();
+  }
+
+  protected function isVerbose(): bool
+  {
+    return in_array('--verbose', $_SERVER['argv']) ||
+      in_array('-v', $_SERVER['argv']) ||
+      in_array('-vv', $_SERVER['argv']) ||
+      in_array('-vvv', $_SERVER['argv']);
+  }
+
+  public function testPackageInstallation()
+  {
+    // Create new Composer application
+    $application = new Application();
+    $application->setAutoExit(false);
+
+    // Run composer install
+    $input = new ArrayInput([
+      'command' => 'install',
+      '--working-dir' => $this->packeDir,
+      '--no-interaction' => true,
+      '--no-progress' => true,
+    ]);
+
+    $bufferedOutput = new BufferedOutput();
+    $exitCode = $application->run($input, $bufferedOutput);
+    // Get the output content
+    $outputContent = $bufferedOutput->fetch();
+
+
+    // Assert composer install was successful.
+    // This doesn't fail if patching fails!
+    $this->assertEquals(
+      0,
+      $exitCode,
+      'Composer install failed: ' . $outputContent
+    );
+
+    // If the output contains patching related error, display it to console
+    if (strpos($outputContent, 'Could not apply patch!') !== false && $this->isVerbose()) {
+      $consoleOutput = new ConsoleOutput();
+      $consoleOutput->write($outputContent);
+    }
+
+    // Verify that vendor directory exists.
+    $this->assertTrue(
+      $this->filesystem->exists($this->vendorDir),
+      'Vendor directory was not created - ' . $outputContent
+    );
+
+    // Verify composer.lock was created
+    $this->assertTrue(
+      $this->filesystem->exists($this->composerLock),
+      'composer.lock file was not created - ' . $outputContent
+    );
+
+    // Check that the local patch from the dependency has been applied.
+    $this->assertTrue(
+      $this->filesystem->exists(
+        $this->vendorDir . '/cweagans/composer-patches-testrepo/src/LocalPatchFromDependency.php'
+      ),
+      'Local patch from dependency was not applied - ' . $outputContent
+    );
+
+    // Check that the local patch from the project has been applied.
+    $this->assertTrue(
+      $this->filesystem->exists(
+        $this->vendorDir . '/cweagans/composer-patches-testrepo/src/LocalPatchFromProject.php'
+      ),
+      'Local patch from project was not applied - ' . $outputContent
+    );
+
+    // Check that the remote patch from a dependency has been applied.
+    $this->assertTrue(
+      $this->filesystem->exists(
+        $this->vendorDir . '/cweagans/composer-patches-testrepo/src/OneMoreTest.php'
+      ),
+      'Remote patch from dependency was not applied - ' . $outputContent
+    );
+
+    // Check that the remote patch from the project has been applied.
+    // Would like to use a second remote patch but can't because these tests are
+    // built to validate the workaround for the github rate limiting issue.
+    // Which we would hit when downloading 2 patches within a minute.
+    // Add the following patch once the rate limiting issue on github is fixed.
+    /*$this->assertTrue(
+      $this->filesystem->exists(
+        $this->vendorDir . '/cweagans/composer-patches-testrepo/src/YetAnotherTest.php'
+      ),
+      'Remote patch from project was not applied'
+    );*/
+  }
+}

--- a/tests/_data/dep-test-dependencies/one/composer.json
+++ b/tests/_data/dep-test-dependencies/one/composer.json
@@ -1,0 +1,13 @@
+{
+  "name": "cweagans/dep-test-dependencies-one",
+  "description": "Project for use in cweagans/composer-patches acceptance tests.",
+  "type": "project",
+  "license": "BSD-3-Clause",
+  "extra": {
+    "patches": {
+      "cweagans/composer-patches-testrepo": {
+        "Local File Patch From Dependency": "./patches/dependency-local-file-patch.patch"
+      }
+    }
+  }
+}

--- a/tests/_data/dep-test-dependencies/one/patches/dependency-local-file-patch.patch
+++ b/tests/_data/dep-test-dependencies/one/patches/dependency-local-file-patch.patch
@@ -1,0 +1,26 @@
+From 12e18c424dfa788b7b872f67aa2fb598cb427959 Mon Sep 17 00:00:00 2001
+From: Cameron Eagans <me@cweagans.net>
+Date: Wed, 1 Feb 2023 16:40:53 -0700
+Subject: [PATCH] Add a different file from a local patch in a dependency
+
+---
+ src/LocalPatchFromDependency.php | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+ create mode 100644 src/LocalPatchFromDependency.php
+
+diff --git a/src/LocalPatchFromDependency.php b/src/LocalPatchFromDependency.php
+new file mode 100644
+index 0000000..06fc6d4
+--- /dev/null
++++ b/src/LocalPatchFromDependency.php
+@@ -0,0 +1,10 @@
++<?php
++
++namespace cweagans\ComposerPatchesTest;
++
++class LocalPatchFromDependency
++{
++    public static function doNothing()
++    {
++    }
++}

--- a/tests/_data/dep-test-dependencies/two/composer.json
+++ b/tests/_data/dep-test-dependencies/two/composer.json
@@ -1,0 +1,13 @@
+{
+  "name": "cweagans/dep-test-dependencies-two",
+  "description": "Project for use in cweagans/composer-patches acceptance tests.",
+  "type": "project",
+  "license": "BSD-3-Clause",
+  "extra": {
+    "patches": {
+      "cweagans/composer-patches-testrepo": {
+        "Add a file": "https://patch-diff.githubusercontent.com/raw/cweagans/composer-patches-testrepo/pull/1.patch"
+      }
+    }
+  }
+}

--- a/tests/_data/dep-test-package/composer.json
+++ b/tests/_data/dep-test-package/composer.json
@@ -1,0 +1,40 @@
+{
+  "name": "cweagans/dep-test-package",
+  "description": "Project for use in cweagans/composer-patches acceptance tests.",
+  "type": "project",
+  "license": "BSD-3-Clause",
+  "repositories": [
+    {
+      "type": "path",
+      "url": "../../../"
+    },
+    {
+      "type": "path",
+      "url": "../dep-test-dependencies/one"
+    },
+    {
+      "type": "path",
+      "url": "../dep-test-dependencies/two"
+    }
+  ],
+  "require": {
+    "cweagans/composer-patches": "*@dev",
+    "cweagans/composer-patches-testrepo": "~1.0",
+    "cweagans/dep-test-dependencies-one": "*@dev",
+    "cweagans/dep-test-dependencies-two": "*@dev"
+  },
+  "extra": {
+    "enable-patching": true,
+    "patches": {
+      "cweagans/composer-patches-testrepo": {
+        "Local File Patch From Project": "./patches/project-local-file-patch.patch",
+        "Remote File Patch From Project": "https://patch-diff.githubusercontent.com/raw/cweagans/composer-patches-testrepo/pull/4.patch"
+      }
+    }
+  },
+  "config": {
+    "allow-plugins": {
+      "cweagans/composer-patches": true
+    }
+  }
+}

--- a/tests/_data/dep-test-package/patches/project-local-file-patch.patch
+++ b/tests/_data/dep-test-package/patches/project-local-file-patch.patch
@@ -1,0 +1,26 @@
+From 12e18c424dfa788b7b872f67aa2fb598cb427959 Mon Sep 17 00:00:00 2001
+From: Cameron Eagans <me@cweagans.net>
+Date: Wed, 1 Feb 2023 16:40:53 -0700
+Subject: [PATCH] Add a different file from a local patch in the project
+
+---
+ src/LocalPatchFromProject.php | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+ create mode 100644 src/LocalPatchFromProject.php
+
+diff --git a/src/LocalPatchFromProject.php b/src/LocalPatchFromProject.php
+new file mode 100644
+index 0000000..06fc6d4
+--- /dev/null
++++ b/src/LocalPatchFromProject.php
+@@ -0,0 +1,10 @@
++<?php
++
++namespace cweagans\ComposerPatchesTest;
++
++class LocalPatchFromProject
++{
++    public static function doNothing()
++    {
++    }
++}


### PR DESCRIPTION
## Description

This is an attempt to find a sane workaround for issues like this: https://github.com/orgs/community/discussions/157887
My assumption is that we'll probably see similar issues as long as the LLM craze with all its wild west bots is active.

Unfortunately we're currently not in a position to upgrade to version 2.x where we most likely could workaround all of this using the new API.
An attempt of using the events available in 1.x with a custom stream wrapper to resolve local patches ended with the fact that PHP's [realpath](http://php.net/realpath)() does not support stream wrappers.

The implemented approach of having project root relative paths should allow to keep a stable ignored patches integration too.

## Related tasks

- [ ] Documentation has been updated if applicable
- [ ] Tests have been added
- [ ] Does not break backwards compatibility _OR_ a BC break has been discussed in the related issue(s).

